### PR TITLE
2026.05.02

### DIFF
--- a/buddybackup.plg
+++ b/buddybackup.plg
@@ -14,7 +14,7 @@
   <!ENTITY emhttp        "/usr/local/emhttp/plugins/&name;">
   <!ENTITY pkgPath       "/boot/config/plugins/&name;">
   <!ENTITY pkgName       "&name;.txz">
-  <!ENTITY pkgMD5        "e39e1fd43e437b26ca7edaae34ca3b29">
+  <!ENTITY pkgMD5        "886e8b64f779b9647c92b05d35db4c25">
 ]>
 
 <PLUGIN  name="&name;"

--- a/buddybackup.plg
+++ b/buddybackup.plg
@@ -4,7 +4,7 @@
   <!ENTITY name         "buddybackup">
   <!ENTITY displayName  "ZFS Buddy Backup">
   <!ENTITY author       "Alexander Wester">
-  <!ENTITY version      "2025.09.13">
+  <!ENTITY version      "2026.05.02">
   <!ENTITY launch       "Settings/BuddyBackup">
   <!ENTITY branch       "main">
   <!ENTITY gitURL       "https://raw.githubusercontent.com/Piratkopia13/unraid-&name;/refs/heads/&branch;">
@@ -14,7 +14,7 @@
   <!ENTITY emhttp        "/usr/local/emhttp/plugins/&name;">
   <!ENTITY pkgPath       "/boot/config/plugins/&name;">
   <!ENTITY pkgName       "&name;.txz">
-  <!ENTITY pkgMD5        "886e8b64f779b9647c92b05d35db4c25">
+  <!ENTITY pkgMD5        "d384fbb66105db10ee103446227331ca">
 ]>
 
 <PLUGIN  name="&name;"
@@ -26,6 +26,14 @@
          >
 <CHANGES>
 ##&name;
+
+###2026.05.02
+- Allow spaces in snapshot and dataset names sent over SSH [#20](https://github.com/Piratkopia13/unraid-buddybackup/issues/20)
+- Fix GUI field alignment that broke in some version of Unraid
+- Handle if ZFS is not available in SSH user buddybackup's PATH
+- Validate destination dataset name during connection testing
+- Validate that ZFS is available and working on the remote during connection testing
+- Reduce false positives for failed security validation during connection testing, and add debug logs if the test still fails
 
 ###2025.09.13
 - Update to sanoid/syncoid 2.3

--- a/src/usr/local/emhttp/plugins/buddybackup/Backups.page
+++ b/src/usr/local/emhttp/plugins/buddybackup/Backups.page
@@ -222,7 +222,7 @@ _(Your SSH public key (send this to you buddy))_:
             <dt>_(Destination dataset)_:</dt>
             <dd>
                 <input type="text" name="destination_dataset" class="align" <?=($data['type']=='local')?'list="local-datasets"':''?> value="<?=$data['destination_dataset'];?>" <?=$disabled?>>
-                <div class="buddybackup-center buddybackup-type-remote" style="color:gray;" <?=($data['type']=='local')?'style="display:none;"':''?>>Note: must begin with buddy's set destination parent dataset, followed by a child dataset name.</span>
+                <div class="buddybackup-field-note buddybackup-type-remote" <?=($data['type']=='local')?'style="display:none;"':''?>>Note: must begin with buddy's set destination parent dataset, followed by a child dataset name.</div>
             </dd>
         </dl>
         </td>

--- a/src/usr/local/emhttp/plugins/buddybackup/Backups.page
+++ b/src/usr/local/emhttp/plugins/buddybackup/Backups.page
@@ -15,10 +15,14 @@ Title="Backup and restore"
     $disabled = ($disable_send) ? "disabled" : "";
 ?>
 <script>
+    function shell_escape_arg(value) {
+        return String(value).replace(/(["\\$`])/g, '\\$1');
+    }
     function test_connection(btn) {
         var form = $(btn).closest("form.buddybackup-backup-entry");
-        ip = form.find('input[name="destination_host"]').val();
-        buddybackup_show_popup('<?=$rc_name?> test_connection "'+ip+'"', '_(Connection test)_', "Testing connection to buddy at "+ip+"..")
+        var ip = shell_escape_arg(form.find('input[name="destination_host"]').val());
+        var destination_dataset = shell_escape_arg(form.find('input[name="destination_dataset"]').val());
+        buddybackup_show_popup('<?=$rc_name?> test_connection "'+ip+'" "'+destination_dataset+'"', '_(Connection test)_', "Testing connection to buddy at "+ip+"..")
     }
     function send_backup(btn) {
         var form = $(btn).closest("form.buddybackup-backup-entry");

--- a/src/usr/local/emhttp/plugins/buddybackup/BuddyBackup.page
+++ b/src/usr/local/emhttp/plugins/buddybackup/BuddyBackup.page
@@ -60,8 +60,41 @@ Tag="buddybackup"
     .buddybackup-center {
         text-align: center !important;
     }
+    .buddybackup-field-note {
+        display: block;
+        margin-top: 4px;
+        color: gray;
+        text-align: left !important;
+    }
     .narrow {
-        width: 20px !important;
+        width: 4ch !important;
+        min-width: 4ch;
+    }
+    .buddy-retention-group {
+        display: block;
+    }
+    .buddy-retention-row {
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: 8px;
+    }
+    .buddy-retention-row:last-child {
+        margin-bottom: 0;
+    }
+    .buddy-retention-item {
+        display: inline-flex;
+        align-items: center;
+        min-width: 180px;
+        margin: 0 24px 0 0;
+    }
+    .buddy-retention-item:last-child {
+        margin-right: 0;
+    }
+    .buddy-retention-item span {
+        margin-left: 8px;
+    }
+    .buddy-retention-item input {
+        margin: 0;
     }
     .buddybackup-list-entry {
         border: 1px solid gray;

--- a/src/usr/local/emhttp/plugins/buddybackup/BuddysBackupSettings.page
+++ b/src/usr/local/emhttp/plugins/buddybackup/BuddysBackupSettings.page
@@ -43,35 +43,44 @@ _(Enable)_:
     > Enable receival of Buddy's backups. Buddy will not be able to connect to you unless this is enabled.
 :end
 
-_(Buddy's SSH public key (get this from your buddy))_:
-: <textarea name="DestinationPubSSHKey" class="align" wrap="off" oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px';" <?=$disabled?>>
+<dl>
+  <dt>_(Buddy's SSH public key (get this from your buddy))_:</dt>
+  <dd>
+    <textarea name="DestinationPubSSHKey" class="align" wrap="off" oninput="this.style.height = 'auto'; this.style.height = this.scrollHeight + 'px';" <?=$disabled?>>
     <?=$cfg['DestinationPubSSHKey'];?>
   </textarea>
+    <div id="buddybackup-multiple-keys" class="buddybackup-field-note">
+      You can add multiple keys, just make sure there is only one key per line.<br>
+    </div>
+  </dd>
+</dl>
 
-<div id="buddybackup-multiple-keys" class="buddybackup-center" style="color:gray; margin-top: -10px;">
-  You can add multiple keys, just make sure there is only one key per line.<br>
-</div>
-<br>
-
-_(Destination parent dataset)_:
-: <select name="ReceiveDestinationDataset" class="align" <?=$disabled?>>
+<dl>
+  <dt>_(Destination parent dataset)_:</dt>
+  <dd>
+    <select name="ReceiveDestinationDataset" class="align" <?=$disabled?>>
   <?=datasets($cfg["ReceiveDestinationDataset"], false)?>
-  </select>
-<div class="buddybackup-center" style="color:gray;">Buddy should prefix their destination dataset with this, but always end with a child dataset.
+    </select>
+    <div class="buddybackup-field-note">Buddy should prefix their destination dataset with this, but always end with a child dataset.
 Buddy can use any child dataset following this as destination, but not this dataset directly.<br>
 <span id="buddybackup-destination-example"></span></div>
-<br>
+  </dd>
+</dl>
 
 _(Snapshot retention)_:
-: <span class="buddy-left"><input type="number" name="ReceiveDestinationRententionHourly" value="<?=$cfg['ReceiveDestinationRententionHourly'];?>" class="narrow"> Hourly</span>
-<input type="number" name="ReceiveDestinationRententionMonthly" value="<?=$cfg['ReceiveDestinationRententionMonthly'];?>" class="narrow"> Monthly
-
-&nbsp;
-: <span class="buddy-left"><input type="number" name="ReceiveDestinationRententionDaily" value="<?=$cfg['ReceiveDestinationRententionDaily'];?>" class="narrow"> Daily</span>
-<input type="number" name="ReceiveDestinationRententionYearly" value="<?=$cfg['ReceiveDestinationRententionYearly'];?>" class="narrow"> Yearly
-
-&nbsp;
-: <span class="buddy-left"><input type="number" name="ReceiveDestinationRententionWeekly" value="<?=$cfg['ReceiveDestinationRententionWeekly'];?>" class="narrow"> Weekly</span>
+: <span class="buddy-retention-group">
+    <span class="buddy-retention-row">
+      <label class="buddy-retention-item"><input type="number" name="ReceiveDestinationRententionHourly" value="<?=$cfg['ReceiveDestinationRententionHourly'];?>" class="narrow"> <span>Hourly</span></label>
+      <label class="buddy-retention-item"><input type="number" name="ReceiveDestinationRententionMonthly" value="<?=$cfg['ReceiveDestinationRententionMonthly'];?>" class="narrow"> <span>Monthly</span></label>
+    </span>
+    <span class="buddy-retention-row">
+      <label class="buddy-retention-item"><input type="number" name="ReceiveDestinationRententionDaily" value="<?=$cfg['ReceiveDestinationRententionDaily'];?>" class="narrow"> <span>Daily</span></label>
+      <label class="buddy-retention-item"><input type="number" name="ReceiveDestinationRententionYearly" value="<?=$cfg['ReceiveDestinationRententionYearly'];?>" class="narrow"> <span>Yearly</span></label>
+    </span>
+    <span class="buddy-retention-row">
+      <label class="buddy-retention-item"><input type="number" name="ReceiveDestinationRententionWeekly" value="<?=$cfg['ReceiveDestinationRententionWeekly'];?>" class="narrow"> <span>Weekly</span></label>
+    </span>
+  </span>
 
 :retention_plug:
     > [Sanoid](https://github.com/jimsalterjrs/sanoid/wiki/Sanoid#options) policy for how many snapshots containing your buddy's backup should be kept. Set this to balance disk usage with number of kept backups that your buddy wants.

--- a/src/usr/local/emhttp/plugins/buddybackup/SnapshotSettings.page
+++ b/src/usr/local/emhttp/plugins/buddybackup/SnapshotSettings.page
@@ -1,12 +1,6 @@
 Menu="BuddyBackup:2"
 Title="Snapshot creation and pruning"
 ---
-<style>
-    .buddy-left {
-        display: inline-block;
-        width: 180px;
-    }
-</style>
 <script>
     function snapshot_input_changed() {
         var form = $(this).parentsUntil('form').parent();
@@ -96,15 +90,19 @@ Set up automatic snapshot creation and pruning on your datasets. You do not need
         </select>
 
         _(Snapshot retention)_:
-        : <span class="buddy-left"><input type="number" name="hourly" value="<?=$data["hourly"]?:0;?>" class="narrow"> Hourly</span>
-        <input type="number" name="monthly" value="<?=$data["monthly"]?:0;?>" class="narrow"> Monthly
-
-        &nbsp;
-        : <span class="buddy-left"><input type="number" name="daily" value="<?=$data["daily"]?:0;?>" class="narrow"> Daily</span>
-        <input type="number" name="yearly" value="<?=$data["yearly"]?:0;?>" class="narrow"> Yearly
-
-        &nbsp;
-        : <span class="buddy-left"><input type="number" name="weekly" value="<?=$data["weekly"]?:0;?>" class="narrow"> Weekly</span>
+        : <span class="buddy-retention-group">
+            <span class="buddy-retention-row">
+                <label class="buddy-retention-item"><input type="number" name="hourly" value="<?=$data["hourly"]?:0;?>" class="narrow"> <span>Hourly</span></label>
+                <label class="buddy-retention-item"><input type="number" name="monthly" value="<?=$data["monthly"]?:0;?>" class="narrow"> <span>Monthly</span></label>
+            </span>
+            <span class="buddy-retention-row">
+                <label class="buddy-retention-item"><input type="number" name="daily" value="<?=$data["daily"]?:0;?>" class="narrow"> <span>Daily</span></label>
+                <label class="buddy-retention-item"><input type="number" name="yearly" value="<?=$data["yearly"]?:0;?>" class="narrow"> <span>Yearly</span></label>
+            </span>
+            <span class="buddy-retention-row">
+                <label class="buddy-retention-item"><input type="number" name="weekly" value="<?=$data["weekly"]?:0;?>" class="narrow"> <span>Weekly</span></label>
+            </span>
+        </span>
 
         _(Trigger backup after snapshot creation)_:
         : <select name="trigger" class="align">

--- a/src/usr/local/emhttp/plugins/buddybackup/common.php
+++ b/src/usr/local/emhttp/plugins/buddybackup/common.php
@@ -3,6 +3,13 @@
     $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
     require_once $docroot."/plugins/dynamix/include/Helpers.php";
 
+    $buddybackup_path = '/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin';
+    $current_path = getenv('PATH') ?: '';
+    $normalized_path = $buddybackup_path . ($current_path !== '' ? ":$current_path" : '');
+    putenv("PATH=$normalized_path");
+    $_ENV['PATH'] = $normalized_path;
+    $_SERVER['PATH'] = $normalized_path;
+
     $cfg = parse_plugin_cfg($plugin, true);
     $rc_name = "rc.$plugin.php";
     $rc_script = "/plugins/$plugin/scripts/$rc_name";

--- a/src/usr/local/emhttp/plugins/buddybackup/deps/restrict_zfs
+++ b/src/usr/local/emhttp/plugins/buddybackup/deps/restrict_zfs
@@ -7,10 +7,10 @@ use Sys::Syslog qw(:standard :macros);
 use Scalar::Util qw(looks_like_number);
 
 my $POOL = qr/'[\w-]+'/;
-my $DATASET = qr/'[\w\/-]+'/;
-my $DATASET_SNAPSHOT = qr/'[\w\/-]+('?)@('?)[\w:-]+'/;
+my $DATASET = qr/'[\w\/ -]+'/;
+my $DATASET_SNAPSHOT = qr/'[\w\/ -]+('?)@('?)[\w:-]+'/;
 
-my $SYNCOID_SNAPSHOT = qr/'[\w\/-]+'@('?)syncoid_[\w:-]+\1/;
+my $SYNCOID_SNAPSHOT = qr/'[\w\/ -]+'@('?)syncoid_[\w:-]+\1/;
 
 my $REDIRS = qr/(?:\s+(?:2>\/dev\/null|2>&1))?/;
 my $PIPE = qr/\s*\|\s*/;

--- a/src/usr/local/emhttp/plugins/buddybackup/deps/restrict_zfs
+++ b/src/usr/local/emhttp/plugins/buddybackup/deps/restrict_zfs
@@ -6,6 +6,8 @@ use Getopt::Long qw(GetOptions);
 use Sys::Syslog qw(:standard :macros);
 use Scalar::Util qw(looks_like_number);
 
+$ENV{'PATH'} = join(':', grep { length } qw(/usr/local/sbin /usr/sbin /sbin /usr/local/bin /usr/bin /bin), ($ENV{'PATH'} // ''));
+
 my $POOL = qr/'[\w-]+'/;
 my $DATASET = qr/'[\w\/ -]+'/;
 my $DATASET_SNAPSHOT = qr/'[\w\/ -]+('?)@('?)[\w:-]+'/;
@@ -34,6 +36,7 @@ my @ALLOWED_COMMANDS = (
     qr/zfs send -w -nvP -I $DATASET_SNAPSHOT\s+$DATASET_SNAPSHOT/,
     qr/zfs send -w\s+$DATASET_SNAPSHOT$PIPE$COMPRESS_CMD\s*$MBUFFER_CMD/,
     qr/zfs send -w\s+-i $DATASET_SNAPSHOT\s+$DATASET_SNAPSHOT$PIPE$COMPRESS_CMD\s*$MBUFFER_CMD/,
+    qr/\/usr\/local\/emhttp\/plugins\/buddybackup\/scripts\/rc.buddybackup.php probe_zfs/,
     qr/\/usr\/local\/emhttp\/plugins\/buddybackup\/scripts\/rc.buddybackup.php mark_received_backup/,
 );
 

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
@@ -58,6 +58,38 @@ json_field() {
     printf '%s' "${json}" | jq -r --arg field "${field}" 'if type == "object" then .[$field] // empty else empty end' 2>/dev/null
 }
 
+sanitize_ssh_output() {
+    # Ignore client-side known_hosts maintenance chatter; it is not remote command output.
+    printf '%s' "$1" | awk '
+        /^hostfile_replace_entries:/ { next }
+        /^update_known_hosts:/ { next }
+        /^Learned new hostkey:/ { next }
+        /^Adding new key for / { next }
+        /^Deprecating obsolete hostkey:/ { next }
+        { print }
+    ' | sed '/^[[:space:]]*$/d'
+}
+
+log_escape_value() {
+    printf '%s' "$1" | jq -Rsa . | sed -e 's/^"//' -e 's/"$//'
+}
+
+append_to_buddybackup_log() {
+    local log_script="${empath}/scripts/log.sh"
+
+    if [[ $# -eq 0 ]]; then
+        return
+    fi
+
+    if [[ -f "${log_script}" ]]; then
+        printf '%s\n' "$@" | /bin/bash "${log_script}"
+    else
+        while IFS= read -r line; do
+            logger "${line}" -t"${plugin}"
+        done <<< "$(printf '%s\n' "$@")"
+    fi
+}
+
 shell_single_quote() {
     printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
 }
@@ -427,10 +459,13 @@ test_connection() {
     local host=$1
     local cmd="${2:-echo ok}"
     # test SSH connection to buddy
-    ssh_status=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "${cmd}" 2>&1)
-    if [[ "${ssh_status}" == ok ]] || [[ "${ssh_status}" == *"hostfile_replace_entries"* ]]; then
+    local ssh_status_raw
+    ssh_status_raw=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "${cmd}" 2>&1)
+    local ssh_status
+    ssh_status=$(sanitize_ssh_output "${ssh_status_raw}")
+    if [[ "${ssh_status}" == ok ]]; then
         echo "connection_status=\"ok\"; connection_result=\"${ssh_status}\""
-    elif [[ "${ssh_status}" == *"Permission denied"* ]] ; then
+    elif [[ "${ssh_status_raw}" == *"Permission denied"* ]] ; then
         echo "connection_status=\"no auth\"; connection_result=\"${ssh_status}\""
     else
         echo "connection_status=\"fail\"; connection_result=\"${ssh_status}\""
@@ -529,9 +564,28 @@ test_connection_cmd() {
             fi
         fi
 
-        eval $(test_connection "${host}" "echo ok && ls")
-        if [[ "${connection_status}" != "fail" ]] || [[ ${connection_result} != "" ]]; then
-            echo "<span style='color:red'>BuddyBackup SSH security validation failed! This could happen if remote is not using BuddyBackup. Backups will still work, but connection is not restriced to backups. This is a security risk.<span>"
+        local security_validation_raw=""
+        security_validation_raw=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "echo ok && ls" 2>&1)
+        local security_validation_status=$?
+        local security_validation_result=""
+        security_validation_result=$(sanitize_ssh_output "${security_validation_raw}")
+
+        if [[ -n "${security_validation_result}" ]] || [[ "${security_validation_raw}" == *"Permission denied"* ]]; then
+            append_to_buddybackup_log \
+                "Test connection security validation failed" \
+                "  host=$(log_escape_value "${host}")" \
+                "  destination_dataset=$(log_escape_value "${destination_dataset}")" \
+                "  initial_connection_status=$(log_escape_value "${connection_status}")" \
+                "  initial_connection_result=$(log_escape_value "${connection_result}")" \
+                "  zfs_probe_status=$(log_escape_value "${zfs_probe_status}")" \
+                "  zfs_probe_result=$(log_escape_value "${zfs_probe_result}")" \
+                "  remote_probe_status=$(log_escape_value "${remote_probe_status}")" \
+                "  remote_receive_dataset=$(log_escape_value "${remote_receive_dataset}")" \
+                "  remote_probe_message=$(log_escape_value "${remote_probe_message}")" \
+                "  security_validation_status=$(log_escape_value "${security_validation_status}")" \
+                "  security_validation_result=$(log_escape_value "${security_validation_result}")" \
+                "  security_validation_raw=$(log_escape_value "${security_validation_raw}")"
+            echo "<span style='color:red'>BuddyBackup SSH security validation failed! This could happen if remote is not using BuddyBackup. Backups will still work, but connection is not restricted to backups. This is a security risk. Check the local BuddyBackup log (/var/log/buddybackup.log) for debug details.<span>"
         fi
     fi
 

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -o pipefail
 
+export PATH="/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin${PATH:+:${PATH}}"
+
 plugin="buddybackup"
 
 list_descendants() {
@@ -405,7 +407,7 @@ test_connection() {
     local host=$1
     local cmd="${2:-echo ok}"
     # test SSH connection to buddy
-    ssh_status=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" $cmd 2>&1)
+    ssh_status=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "${cmd}" 2>&1)
     if [[ "${ssh_status}" == ok ]] || [[ "${ssh_status}" == *"hostfile_replace_entries"* ]]; then
         echo "connection_status=\"ok\"; connection_result=\"${ssh_status}\""
     elif [[ "${ssh_status}" == *"Permission denied"* ]] ; then
@@ -417,6 +419,7 @@ test_connection() {
 
 test_connection_cmd() {
     local host=$1
+    local destination_dataset=$2
     echo "<h2>Trying to connect to ${host} over SSH..<br>"
 
     local success=0
@@ -432,6 +435,74 @@ test_connection_cmd() {
     esac
 
     if [[ $success -eq 1 ]]; then
+        local zfs_probe_cmd="/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php probe_zfs"
+        local zfs_probe_result
+        zfs_probe_result=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "${zfs_probe_cmd}" 2>&1)
+        local zfs_probe_status=$?
+
+        local remote_receive_dataset=""
+        local remote_probe_message=""
+        local remote_probe_status=""
+        if [[ "${zfs_probe_result}" == status=* ]]; then
+            while IFS= read -r line; do
+                case "${line}" in
+                    status=*)
+                        remote_probe_status="${line#status=}"
+                    ;;
+                    dataset=*)
+                        remote_receive_dataset="${line#dataset=}"
+                    ;;
+                    message=*)
+                        remote_probe_message="${line#message=}"
+                    ;;
+                esac
+            done <<< "${zfs_probe_result}"
+        elif [[ "${zfs_probe_result}" == "ok" ]]; then
+            remote_probe_status="ok"
+        fi
+
+        if [[ "${remote_probe_status}" == "ok" ]] && [[ -n "${remote_receive_dataset}" ]]; then
+            echo "Buddy's configured receive dataset: ${remote_receive_dataset}<br>"
+
+            if [[ -z "${destination_dataset}" ]]; then
+                echo "<span style='color:#996600'>Destination dataset is blank. It should begin with '${remote_receive_dataset}/'.</span><br>"
+            elif [[ "${destination_dataset}" == "${remote_receive_dataset}/"* ]]; then
+                echo "Destination dataset is under the receiver's configured dataset.<br>"
+            elif [[ "${destination_dataset}" == "${remote_receive_dataset}" ]]; then
+                echo "<span style='color:red'>Destination dataset must be a child dataset under '${remote_receive_dataset}', not the parent dataset itself.</span><br>"
+            else
+                echo "<span style='color:red'>Destination dataset '${destination_dataset}' does not begin with '${remote_receive_dataset}/'.</span><br>"
+            fi
+        elif [[ "${zfs_probe_result}" != "ok" ]]; then
+            if [[ -z "${zfs_probe_result}" ]] && [[ -n "${destination_dataset}" ]]; then
+                local probe_dataset="${destination_dataset%/*}"
+                if [[ -z "${probe_dataset}" ]] || [[ "${probe_dataset}" == "${destination_dataset}" ]]; then
+                    probe_dataset="${destination_dataset}"
+                fi
+
+                local legacy_probe_cmd="zfs get -H name '${probe_dataset}'"
+                zfs_probe_result=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "${legacy_probe_cmd}" 2>&1)
+                zfs_probe_status=$?
+                local legacy_probe_line="${zfs_probe_result%%$'\n'*}"
+                local legacy_probe_name=""
+                local legacy_probe_property=""
+                local legacy_probe_value=""
+                IFS=$'\t' read -r legacy_probe_name legacy_probe_property legacy_probe_value _ <<< "${legacy_probe_line}"
+                if [[ $zfs_probe_status -ne 0 ]] || [[ "${legacy_probe_property}" != "name" ]] || [[ "${legacy_probe_value}" != "${probe_dataset}" ]]; then
+                    echo "<span style='color:red'>Connected, but the receiver is running an older BuddyBackup version, so BuddyBackup fell back to probing '${probe_dataset}'. That legacy ZFS probe failed. Result: ${zfs_probe_result}</span><br>"
+                else
+                    echo "<span style='color:#996600'>Connected. The receiver is running an older BuddyBackup version, so BuddyBackup used a legacy ZFS probe on '${probe_dataset}'.</span><br>"
+                    echo "The legacy probe succeeded, but this receiver does not report its configured receive dataset yet, so the destination dataset prefix could not be validated automatically.<br>"
+                fi
+            elif [[ -z "${zfs_probe_result}" ]]; then
+                echo "<span style='color:#996600'>Connected, but this buddy's BuddyBackup version does not support the host-only ZFS probe yet. Fill in the destination dataset or update the receiving server to fully verify remote ZFS access here.</span><br>"
+            elif [[ "${remote_probe_status}" == "error" ]]; then
+                echo "<span style='color:red'>Connected, but BuddyBackup could not run the remote ZFS probe. This usually means the buddybackup user cannot resolve or run ZFS commands yet. Result: ${remote_probe_message}</span><br>"
+            else
+                echo "<span style='color:red'>Connected, but BuddyBackup could not run the remote ZFS probe. This usually means the buddybackup user cannot resolve or run ZFS commands yet. Result: ${zfs_probe_result}</span><br>"
+            fi
+        fi
+
         eval $(test_connection "${host}" "echo ok && ls")
         if [[ "${connection_status}" != "fail" ]] || [[ ${connection_result} != "" ]]; then
             echo "<span style='color:red'>BuddyBackup SSH security validation failed! This could happen if remote is not using BuddyBackup. Backups will still work, but connection is not restriced to backups. This is a security risk.<span>"
@@ -585,7 +656,7 @@ case "$1" in
 		send_local_backup "${2}" "${3}" "${4}" "${5}"
 	;;
     ('test_connection')
-		test_connection_cmd "${2}"
+        test_connection_cmd "${2}" "${3}"
 	;;
     ('get_available_snapshots')
         get_available_snapshots "${2}" "${3}" "${4}"

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
@@ -51,6 +51,13 @@ html_escape() {
         -e "s/'/\&#39;/g"
 }
 
+json_field() {
+    local json="$1"
+    local field="$2"
+
+    printf '%s' "${json}" | jq -r --arg field "${field}" 'if type == "object" then .[$field] // empty else empty end' 2>/dev/null
+}
+
 shell_single_quote() {
     printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
 }
@@ -462,22 +469,12 @@ test_connection_cmd() {
         local remote_receive_dataset=""
         local remote_probe_message=""
         local remote_probe_status=""
-        if [[ "${zfs_probe_result}" == status=* ]]; then
-            while IFS= read -r line; do
-                case "${line}" in
-                    status=*)
-                        remote_probe_status="${line#status=}"
-                    ;;
-                    dataset=*)
-                        remote_receive_dataset="${line#dataset=}"
-                    ;;
-                    message=*)
-                        remote_probe_message="${line#message=}"
-                    ;;
-                esac
-            done <<< "${zfs_probe_result}"
-        elif [[ "${zfs_probe_result}" == "ok" ]]; then
-            remote_probe_status="ok"
+        if [[ "${zfs_probe_result}" == \{* ]]; then
+            remote_probe_status=$(json_field "${zfs_probe_result}" "status")
+            if [[ -n "${remote_probe_status}" ]]; then
+                remote_receive_dataset=$(json_field "${zfs_probe_result}" "dataset")
+                remote_probe_message=$(json_field "${zfs_probe_result}" "message")
+            fi
         fi
 
         if [[ "${remote_probe_status}" == "ok" ]] && [[ -n "${remote_receive_dataset}" ]]; then

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
@@ -51,6 +51,10 @@ html_escape() {
         -e "s/'/\&#39;/g"
 }
 
+shell_single_quote() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+}
+
 # Runs cmd and continously sends output to nchan if specified, otherwise runs cmd and echos result afterwards
 run_and_write_output() {
     local nchan="$1"  # Set to empty string to only write to console. Otherwise it will be sent to the nchan channel with this name
@@ -497,7 +501,7 @@ test_connection_cmd() {
                     probe_dataset="${destination_dataset}"
                 fi
 
-                local legacy_probe_cmd="zfs get -H name '${probe_dataset}'"
+                local legacy_probe_cmd="zfs get -H name $(shell_single_quote "${probe_dataset}")"
                 zfs_probe_result=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${host}" "${legacy_probe_cmd}" 2>&1)
                 zfs_probe_status=$?
                 local legacy_probe_line="${zfs_probe_result%%$'\n'*}"
@@ -546,7 +550,7 @@ get_available_snapshots() {
     fi
     local destination_dataset="${2}"
 
-    local cmd="zfs list -o name,origin -t filesystem,volume -Hr '${destination_dataset}'"
+    local cmd="zfs list -o name,origin -t filesystem,volume -Hr $(shell_single_quote "${destination_dataset}")"
 
     local result=""
     if [[ "${type}" == "remote" ]]; then
@@ -576,7 +580,7 @@ get_available_snapshots() {
         fi
 
         dataset=$(echo "${line}" | sed 's/\s.*$//')
-        cmds+=( "zfs get -Hpd 1 -t snapshot guid,creation '${dataset}'" )
+        cmds+=( "zfs get -Hpd 1 -t snapshot guid,creation $(shell_single_quote "${dataset}")" )
         datasets+=( "${dataset}" )
     done <<< "${result}"
     
@@ -627,7 +631,7 @@ get_buddy_used_size() {
     local destination_host="${1}"
     local destination_dataset="${2}"
 
-    local cmd="zfs get -H -o value used '${destination_dataset}'"
+    local cmd="zfs get -H -o value used $(shell_single_quote "${destination_dataset}")"
     local ssh_result=$(ssh -i "${ssh_key_path}" -o BatchMode=yes -o ConnectTimeout=5 "${username}@${destination_host}" "${cmd}" 2>&1)
     local error_code=$?
     if [[ $error_code -eq 0 ]] && [[ -z "${ssh_result}" ]]; then

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup
@@ -42,6 +42,15 @@ write() {
     done
 }
 
+html_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g' \
+        -e "s/'/\&#39;/g"
+}
+
 # Runs cmd and continously sends output to nchan if specified, otherwise runs cmd and echos result afterwards
 run_and_write_output() {
     local nchan="$1"  # Set to empty string to only write to console. Otherwise it will be sent to the nchan channel with this name
@@ -420,17 +429,23 @@ test_connection() {
 test_connection_cmd() {
     local host=$1
     local destination_dataset=$2
-    echo "<h2>Trying to connect to ${host} over SSH..<br>"
+    local host_html
+    host_html=$(html_escape "${host}")
+    local destination_dataset_html
+    destination_dataset_html=$(html_escape "${destination_dataset}")
+    echo "<h2>Trying to connect to ${host_html} over SSH..<br>"
 
     local success=0
     eval $(test_connection "${host}")
+    local connection_result_html
+    connection_result_html=$(html_escape "${connection_result}")
     case "${connection_status}" in
         ("ok")
             echo "Success!<br>"
             success=1
         ;;
         ("no auth") echo "Authentication failed. Make sure buddy has enabled \"Buddy's Backups\" and entered your public key.<br>" ;;
-        ("fail") echo "Failed: ${connection_result}<br>" ;;
+        ("fail") echo "Failed: ${connection_result_html}<br>" ;;
         (*) echo "unexpected error" ;;
     esac
 
@@ -462,16 +477,18 @@ test_connection_cmd() {
         fi
 
         if [[ "${remote_probe_status}" == "ok" ]] && [[ -n "${remote_receive_dataset}" ]]; then
-            echo "Buddy's configured receive dataset: ${remote_receive_dataset}<br>"
+            local remote_receive_dataset_html
+            remote_receive_dataset_html=$(html_escape "${remote_receive_dataset}")
+            echo "Buddy's configured receive dataset: ${remote_receive_dataset_html}<br>"
 
             if [[ -z "${destination_dataset}" ]]; then
-                echo "<span style='color:#996600'>Destination dataset is blank. It should begin with '${remote_receive_dataset}/'.</span><br>"
+                echo "<span style='color:#996600'>Destination dataset is blank. It should begin with '${remote_receive_dataset_html}/'.</span><br>"
             elif [[ "${destination_dataset}" == "${remote_receive_dataset}/"* ]]; then
                 echo "Destination dataset is under the receiver's configured dataset.<br>"
             elif [[ "${destination_dataset}" == "${remote_receive_dataset}" ]]; then
-                echo "<span style='color:red'>Destination dataset must be a child dataset under '${remote_receive_dataset}', not the parent dataset itself.</span><br>"
+                echo "<span style='color:red'>Destination dataset must be a child dataset under '${remote_receive_dataset_html}', not the parent dataset itself.</span><br>"
             else
-                echo "<span style='color:red'>Destination dataset '${destination_dataset}' does not begin with '${remote_receive_dataset}/'.</span><br>"
+                echo "<span style='color:red'>Destination dataset '${destination_dataset_html}' does not begin with '${remote_receive_dataset_html}/'.</span><br>"
             fi
         elif [[ "${zfs_probe_result}" != "ok" ]]; then
             if [[ -z "${zfs_probe_result}" ]] && [[ -n "${destination_dataset}" ]]; then
@@ -487,19 +504,27 @@ test_connection_cmd() {
                 local legacy_probe_name=""
                 local legacy_probe_property=""
                 local legacy_probe_value=""
+                local probe_dataset_html
+                probe_dataset_html=$(html_escape "${probe_dataset}")
+                local zfs_probe_result_html
+                zfs_probe_result_html=$(html_escape "${zfs_probe_result}")
                 IFS=$'\t' read -r legacy_probe_name legacy_probe_property legacy_probe_value _ <<< "${legacy_probe_line}"
                 if [[ $zfs_probe_status -ne 0 ]] || [[ "${legacy_probe_property}" != "name" ]] || [[ "${legacy_probe_value}" != "${probe_dataset}" ]]; then
-                    echo "<span style='color:red'>Connected, but the receiver is running an older BuddyBackup version, so BuddyBackup fell back to probing '${probe_dataset}'. That legacy ZFS probe failed. Result: ${zfs_probe_result}</span><br>"
+                    echo "<span style='color:red'>Connected, but the receiver is running an older BuddyBackup version, so BuddyBackup fell back to probing '${probe_dataset_html}'. That legacy ZFS probe failed. Result: ${zfs_probe_result_html}</span><br>"
                 else
-                    echo "<span style='color:#996600'>Connected. The receiver is running an older BuddyBackup version, so BuddyBackup used a legacy ZFS probe on '${probe_dataset}'.</span><br>"
+                    echo "<span style='color:#996600'>Connected. The receiver is running an older BuddyBackup version, so BuddyBackup used a legacy ZFS probe on '${probe_dataset_html}'.</span><br>"
                     echo "The legacy probe succeeded, but this receiver does not report its configured receive dataset yet, so the destination dataset prefix could not be validated automatically.<br>"
                 fi
             elif [[ -z "${zfs_probe_result}" ]]; then
                 echo "<span style='color:#996600'>Connected, but this buddy's BuddyBackup version does not support the host-only ZFS probe yet. Fill in the destination dataset or update the receiving server to fully verify remote ZFS access here.</span><br>"
             elif [[ "${remote_probe_status}" == "error" ]]; then
-                echo "<span style='color:red'>Connected, but BuddyBackup could not run the remote ZFS probe. This usually means the buddybackup user cannot resolve or run ZFS commands yet. Result: ${remote_probe_message}</span><br>"
+                local remote_probe_message_html
+                remote_probe_message_html=$(html_escape "${remote_probe_message}")
+                echo "<span style='color:red'>Connected, but BuddyBackup could not run the remote ZFS probe. This usually means the buddybackup user cannot resolve or run ZFS commands yet. Result: ${remote_probe_message_html}</span><br>"
             else
-                echo "<span style='color:red'>Connected, but BuddyBackup could not run the remote ZFS probe. This usually means the buddybackup user cannot resolve or run ZFS commands yet. Result: ${zfs_probe_result}</span><br>"
+                local zfs_probe_result_html
+                zfs_probe_result_html=$(html_escape "${zfs_probe_result}")
+                echo "<span style='color:red'>Connected, but BuddyBackup could not run the remote ZFS probe. This usually means the buddybackup user cannot resolve or run ZFS commands yet. Result: ${zfs_probe_result_html}</span><br>"
             fi
         fi
 

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php
@@ -62,6 +62,58 @@ function file_exists_and_not_empty($file) {
     return file_exists($file) && filesize($file) > 1;
 }
 
+function is_valid_zfs_dataset_name($dataset) {
+    if ($dataset === '') {
+        return false;
+    }
+
+    if (preg_match('/[\x00-\x1F\x7F]/', $dataset)) {
+        return false;
+    }
+
+    if (strpos($dataset, '@') !== false || strpos($dataset, '#') !== false) {
+        return false;
+    }
+
+    return preg_match('/^(?!\/)(?!.*\/\/)(?!.*\/$)[^\/]+(?:\/[^\/]+)*$/', $dataset) === 1;
+}
+
+function read_receive_destination_dataset(&$error_message = null) {
+    global $tmp_recv_dataset_path;
+
+    if (!file_exists($tmp_recv_dataset_path)) {
+        $error_message = 'Buddy receive destination dataset is not configured.';
+        return null;
+    }
+
+    $dataset = trim((string)file_get_contents($tmp_recv_dataset_path));
+    if ($dataset === '') {
+        $error_message = 'Buddy receive destination dataset is not configured.';
+        return null;
+    }
+
+    if (!is_valid_zfs_dataset_name($dataset)) {
+        $error_message = 'Buddy receive destination dataset is invalid.';
+        return null;
+    }
+
+    return $dataset;
+}
+
+function write_probe_zfs_response($status, $dataset = null, $message = null) {
+    $response = array('status' => $status);
+
+    if ($dataset !== null) {
+        $response['dataset'] = $dataset;
+    }
+
+    if ($message !== null) {
+        $response['message'] = $message;
+    }
+
+    echo json_encode($response, JSON_UNESCAPED_SLASHES);
+}
+
 // update() runs on system boot, on plugin install/update, and when backup settings are changed.
 function update() {
     global $rc;
@@ -313,25 +365,32 @@ function get_available_snapshots($uid) {
 
 // Write tmp file with timestamp and size of destination dataset. Used in Unraid dashboard.
 function mark_received_backup() {
-    global $tmp_recv_dataset_path;
-    $dataset = file_get_contents($tmp_recv_dataset_path);
-    $dest_size = exec("zfs get -H -o value used \"".$dataset."\"");
+    $error_message = null;
+    $dataset = read_receive_destination_dataset($error_message);
+    if ($dataset === null) {
+        BB_ERR($error_message);
+        return;
+    }
+
+    $output = array();
+    $result_code = 0;
+    exec("zfs get -H -o value used " . escapeshellarg($dataset) . " 2>&1", $output, $result_code);
+    if ($result_code !== 0) {
+        BB_ERR("Failed to get used size for buddy receive destination dataset '$dataset': " . implode("\n", $output));
+        return;
+    }
+
+    $dest_size = trim(implode("\n", $output));
     $file = "/tmp/buddybackup-buddy";
     $info = "last_ran=".time()."\ndest_size=$dest_size";
     file_put_contents($file, $info);
 }
 
 function probe_zfs() {
-    global $tmp_recv_dataset_path;
-
-    if (!file_exists($tmp_recv_dataset_path)) {
-        echo "status=error\nmessage=Buddy receive destination dataset is not configured.";
-        exit(1);
-    }
-
-    $dataset = trim((string)file_get_contents($tmp_recv_dataset_path));
-    if ($dataset === '') {
-        echo "status=error\nmessage=Buddy receive destination dataset is not configured.";
+    $error_message = null;
+    $dataset = read_receive_destination_dataset($error_message);
+    if ($dataset === null) {
+        write_probe_zfs_response('error', null, $error_message);
         exit(1);
     }
 
@@ -339,11 +398,12 @@ function probe_zfs() {
     $result_code = 0;
     exec("zfs get -H -o value used " . escapeshellarg($dataset) . " 2>&1", $output, $result_code);
     if ($result_code === 0) {
-        echo "status=ok\ndataset=$dataset";
+        write_probe_zfs_response('ok', $dataset, null);
         return;
     }
 
-    echo "status=error\nmessage=" . implode("\n", $output);
+    $message = implode("\n", $output);
+    write_probe_zfs_response('error', null, $message);
     exit($result_code === 0 ? 1 : $result_code);
 }
 
@@ -409,7 +469,7 @@ switch ($argv[1]) {
         break;
     
     default:
-        echo "usage ".$argv[0]." update|send_backup|get_available_snapshots|mark_received_backup|restore_snapshot";
+        echo "usage ".$argv[0]." update|send_backup|get_available_snapshots|probe_zfs|mark_received_backup|restore_snapshot";
         break;
 }
 ?>

--- a/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php
+++ b/src/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php
@@ -11,6 +11,13 @@ $extra_sanoid_config_path = "$plugin_path/snapshots.cfg";
 $sanoid_cron_path = "$plugin_path/sanoid.cron";
 $tmp_recv_dataset_path = "/tmp/buddybackup-recv-dest";
 
+$buddybackup_path = '/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin';
+$current_path = getenv('PATH') ?: '';
+$normalized_path = $buddybackup_path . ($current_path !== '' ? ":$current_path" : '');
+putenv("PATH=$normalized_path");
+$_ENV['PATH'] = $normalized_path;
+$_SERVER['PATH'] = $normalized_path;
+
 $empath = "/usr/local/emhttp/plugins/buddybackup";
 $sanoid_bin = "$empath/deps/sanoid";
 $log_script = "$empath/scripts/log.sh";
@@ -168,6 +175,7 @@ function update_sanoid_conf() {
 function enable_sanoid_cron() {
     global $sanoid_cron_path;
     global $sanoid_bin;
+    global $buddybackup_path;
     global $plugin_path;
     global $log_script;
     global $plugin_config_path;
@@ -176,8 +184,9 @@ function enable_sanoid_cron() {
         ENSURE_SUCCESS(unlink($sanoid_cron_path));
     }
     $tz = ($plugin_cfg["UtcTimezone"] == "yes") ? "TZ=UTC" : "";
+    $command_env = "PATH=$buddybackup_path" . ($tz !== "" ? " $tz" : "");
     $cron_content = "# Generated cron settings for plugin buddybackup\n";
-    $cron_content .= "*/15 * * * * flock -n /var/lock/buddybackup-sanoid-cron -c \"$tz $sanoid_bin --configdir=\"$plugin_path\" --cron\" 2>&1 | $log_script\n";
+    $cron_content .= "*/15 * * * * flock -n /var/lock/buddybackup-sanoid-cron -c \"$command_env $sanoid_bin --configdir=\"$plugin_path\" --cron\" 2>&1 | $log_script\n";
     ENSURE_SUCCESS(file_put_contents($sanoid_cron_path, $cron_content)!==false);
     BB_VERBOSE("Created $sanoid_cron_path");
     passthru("/usr/local/sbin/update_cron");
@@ -312,6 +321,32 @@ function mark_received_backup() {
     file_put_contents($file, $info);
 }
 
+function probe_zfs() {
+    global $tmp_recv_dataset_path;
+
+    if (!file_exists($tmp_recv_dataset_path)) {
+        echo "status=error\nmessage=Buddy receive destination dataset is not configured.";
+        exit(1);
+    }
+
+    $dataset = trim((string)file_get_contents($tmp_recv_dataset_path));
+    if ($dataset === '') {
+        echo "status=error\nmessage=Buddy receive destination dataset is not configured.";
+        exit(1);
+    }
+
+    $output = array();
+    $result_code = 0;
+    exec("zfs get -H -o value used " . escapeshellarg($dataset) . " 2>&1", $output, $result_code);
+    if ($result_code === 0) {
+        echo "status=ok\ndataset=$dataset";
+        return;
+    }
+
+    echo "status=error\nmessage=" . implode("\n", $output);
+    exit($result_code === 0 ? 1 : $result_code);
+}
+
 function send_backup($uid, $echo_pid_arg) {
     BB_LOG("Sending backup $uid");
     global $rc;
@@ -353,10 +388,15 @@ switch ($argv[1]) {
         send_backup($argv[2], $argv[3]);
         break;
     case 'test_connection':
-        passthru($rc.' '.$argv[1].' '.$argv[2]);
+        $host = escapeshellarg($argv[2] ?? '');
+        $destination_dataset = escapeshellarg($argv[3] ?? '');
+        passthru($rc.' test_connection '.$host.' '.$destination_dataset);
         break;
     case 'get_available_snapshots':
         get_available_snapshots($argv[2]);
+        break;
+    case 'probe_zfs':
+        probe_zfs();
         break;
     case 'mark_received_backup':
         mark_received_backup();

--- a/t/restrict_zfs.t
+++ b/t/restrict_zfs.t
@@ -13,6 +13,18 @@ my $script = File::Spec->rel2abs(File::Spec->catfile(
 
 ok(-f $script, 'restrict_zfs script exists');
 
+my $script_source = do {
+    open my $fh, '<', $script or die "Unable to read $script: $!";
+    local $/;
+    <$fh>;
+};
+
+like(
+    $script_source,
+    qr!join\(':',\s*grep\s*\{\s*length\s*\}\s*qw\(/usr/local/sbin /usr/sbin /sbin /usr/local/bin /usr/bin /bin\)!s,
+    'restrict_zfs normalizes PATH to include sbin directories'
+);
+
 sub run_restrict {
     my ($command) = @_;
 
@@ -162,6 +174,11 @@ subtest 'allowed commands' => sub {
             label => 'receive reset',
             command => qq{zfs receive -A $dataset},
             expected_lines => [qq{would run command: zfs receive -A $dataset}],
+        },
+        {
+            label => 'zfs probe callback',
+            command => q{/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php probe_zfs},
+            expected_lines => ['would run command: /usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php probe_zfs'],
         },
         {
             label => 'mark received backup callback',

--- a/t/restrict_zfs.t
+++ b/t/restrict_zfs.t
@@ -286,8 +286,8 @@ subtest 'blocked commands' => sub {
         },
         {
             label => 'command substitution attempt',
-            command => qq{zfs get -H name $dataset4(id)},
-            expected_lines => [qq{blocked command: zfs get -H name $dataset4(id)}],
+            command => qq{zfs get -H name $dataset \$(id)},
+            expected_lines => [qq{blocked command: zfs get -H name $dataset \$(id)}],
         },
         {
             label => 'backtick substitution attempt',

--- a/t/restrict_zfs.t
+++ b/t/restrict_zfs.t
@@ -1,0 +1,311 @@
+use strict;
+use warnings;
+
+use File::Spec;
+use FindBin qw($Bin);
+use IPC::Open3 qw(open3);
+use Symbol qw(gensym);
+use Test::More;
+
+my $script = File::Spec->rel2abs(File::Spec->catfile(
+    $Bin, '..', 'src', 'usr', 'local', 'emhttp', 'plugins', 'buddybackup', 'deps', 'restrict_zfs'
+));
+
+ok(-f $script, 'restrict_zfs script exists');
+
+sub run_restrict {
+    my ($command) = @_;
+
+    local %ENV = %ENV;
+    $ENV{SSH_ORIGINAL_COMMAND} = $command;
+
+    my $stderr = gensym;
+    my $pid = open3(undef, my $stdout, $stderr, $^X, $script, '--dry-run', '--log=stderr');
+    my $stdout_text = do { local $/; <$stdout> // '' };
+    my $stderr_text = do { local $/; <$stderr> // '' };
+    waitpid($pid, 0);
+
+    return {
+        exit_code => $? >> 8,
+        stdout => $stdout_text,
+        stderr => $stderr_text,
+    };
+}
+
+sub stderr_regex {
+    my (@lines) = @_;
+    my $pattern = join('\r?\n', map { quotemeta($_) } @lines);
+    return qr/^$pattern\r?\n?$/;
+}
+
+sub assert_case {
+    my ($label, $command, $expected_lines) = @_;
+
+    my $result = run_restrict($command);
+    is($result->{exit_code}, 0, "$label exits cleanly");
+    is($result->{stdout}, '', "$label does not write to stdout");
+    like($result->{stderr}, stderr_regex(@$expected_lines), "$label logs expected stderr") or diag($result->{stderr});
+}
+
+my $dataset = q{'disk11/backups/tim/cache_domains/Windows 11'};
+my $snap1 = q{'disk11/backups/tim/cache_domains/Windows 11@syncoid_Tower_2026-04-27:01:30:48-GMT01:00'};
+my $snap2 = q{'disk11/backups/tim/cache_domains/Windows 11@autosnap_2026-04-23_06:15:01_daily'};
+
+subtest 'allowed commands' => sub {
+    my @cases = (
+        {
+            label => 'whitespace-trimmed echo ok probe',
+            command => "  echo ok  ",
+            expected_lines => ['would run command: echo ok'],
+        },
+        {
+            label => 'echo -n probe',
+            command => q{echo -n},
+            expected_lines => ['would run command: echo -n'],
+        },
+        {
+            label => 'exit probe',
+            command => q{exit},
+            expected_lines => ['would run command: exit'],
+        },
+        {
+            label => 'zstdmt availability probe',
+            command => q{command -v zstdmt},
+            expected_lines => ['would run command: command -v zstdmt'],
+        },
+        {
+            label => 'mbuffer availability probe',
+            command => q{command -v mbuffer},
+            expected_lines => ['would run command: command -v mbuffer'],
+        },
+        {
+            label => 'resume feature probe',
+            command => q{zpool get -o value -H feature@extensible_dataset 'disk11'},
+            expected_lines => [q{would run command: zpool get -o value -H feature@extensible_dataset 'disk11'}],
+        },
+        {
+            label => 'receive busy check',
+            command => q{ps -Ao args=},
+            expected_lines => ['would run command: ps -Ao args='],
+        },
+        {
+            label => 'target exists query',
+            command => qq{zfs get -H name $dataset},
+            expected_lines => [qq{would run command: zfs get -H name $dataset}],
+        },
+        {
+            label => 'receive token query',
+            command => qq{zfs get -H receive_resume_token $dataset},
+            expected_lines => [qq{would run command: zfs get -H receive_resume_token $dataset}],
+        },
+        {
+            label => 'used size query',
+            command => qq{zfs get -H -o value used $dataset},
+            expected_lines => [qq{would run command: zfs get -H -o value used $dataset}],
+        },
+        {
+            label => 'precise used size query',
+            command => qq{zfs get -H -p used $dataset},
+            expected_lines => [qq{would run command: zfs get -H -p used $dataset}],
+        },
+        {
+            label => 'syncoid sync property query',
+            command => qq{zfs get -H syncoid:sync $dataset},
+            expected_lines => [qq{would run command: zfs get -H syncoid:sync $dataset}],
+        },
+        {
+            label => 'dataset list query',
+            command => qq{zfs list -o name,origin -t filesystem,volume -Hr $dataset},
+            expected_lines => [qq{would run command: zfs list -o name,origin -t filesystem,volume -Hr $dataset}],
+        },
+        {
+            label => 'snapshot metadata query',
+            command => qq{zfs get -Hpd 1 -t snapshot guid,creation $dataset},
+            expected_lines => [qq{would run command: zfs get -Hpd 1 -t snapshot guid,creation $dataset}],
+        },
+        {
+            label => 'bookmark metadata query',
+            command => qq{zfs get -Hpd 1 -t bookmark guid,creation $dataset},
+            expected_lines => [qq{would run command: zfs get -Hpd 1 -t bookmark guid,creation $dataset}],
+        },
+        {
+            label => 'fallback metadata query',
+            command => qq{zfs get -Hpd 1 type,guid,creation $dataset},
+            expected_lines => [qq{would run command: zfs get -Hpd 1 type,guid,creation $dataset}],
+        },
+        {
+            label => 'full send size estimate',
+            command => qq{zfs send -w -nvP $snap1},
+            expected_lines => [qq{would run command: zfs send -w -nvP $snap1}],
+        },
+        {
+            label => 'incremental send size estimate',
+            command => qq{zfs send -w -nvP -I $snap1 $snap2},
+            expected_lines => [qq{would run command: zfs send -w -nvP -I $snap1 $snap2}],
+        },
+        {
+            label => 'full send pipeline',
+            command => qq{zfs send -w $snap1 | zstdmt -3 | mbuffer  -q -s 128k -m 16M},
+            expected_lines => [qq{would run command: zfs send -w $snap1 | zstdmt -3 | mbuffer  -q -s 128k -m 16M}],
+        },
+        {
+            label => 'incremental send pipeline',
+            command => qq{zfs send -w -i $snap1 $snap2 | zstdmt -3 | mbuffer  -q -s 128k -m 16M},
+            expected_lines => [qq{would run command: zfs send -w -i $snap1 $snap2 | zstdmt -3 | mbuffer  -q -s 128k -m 16M}],
+        },
+        {
+            label => 'receive pipeline',
+            command => qq{mbuffer  -q -s 128k -m 16M | zstdmt -dc | zfs receive -F $dataset 2>&1},
+            expected_lines => [qq{would run command: mbuffer  -q -s 128k -m 16M | zstdmt -dc | zfs receive -F $dataset 2>&1}],
+        },
+        {
+            label => 'receive reset',
+            command => qq{zfs receive -A $dataset},
+            expected_lines => [qq{would run command: zfs receive -A $dataset}],
+        },
+        {
+            label => 'mark received backup callback',
+            command => q{/usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php mark_received_backup},
+            expected_lines => ['would run command: /usr/local/emhttp/plugins/buddybackup/scripts/rc.buddybackup.php mark_received_backup'],
+        },
+        {
+            label => 'multiple allowed commands',
+            command => q{echo ok; echo -n},
+            expected_lines => [
+                'would run command: echo ok',
+                'would run command: echo -n',
+            ],
+        },
+    );
+
+    for my $case (@cases) {
+        assert_case($case->{label}, $case->{command}, $case->{expected_lines});
+    }
+};
+
+subtest 'blocked commands' => sub {
+    my $newline_attack = "echo ok\nls";
+
+    my @cases = (
+        {
+            label => 'security validation bypass attempt',
+            command => q{echo ok && ls},
+            expected_lines => ['blocked command: echo ok && ls'],
+        },
+        {
+            label => 'shell chaining after allowed query',
+            command => qq{zfs get -H name $dataset && id},
+            expected_lines => [qq{blocked command: zfs get -H name $dataset && id}],
+        },
+        {
+            label => 'unquoted dataset',
+            command => q{zfs get -H name disk11/backups/tim/cache_domains/Windows_11},
+            expected_lines => ['blocked command: zfs get -H name disk11/backups/tim/cache_domains/Windows_11'],
+        },
+        {
+            label => 'double quoted dataset',
+            command => q{zfs get -H name "disk11/backups/tim/cache_domains/Windows 11"},
+            expected_lines => ['blocked command: zfs get -H name "disk11/backups/tim/cache_domains/Windows 11"'],
+        },
+        {
+            label => 'sudo-prefixed command',
+            command => qq{sudo zfs get -H name $dataset},
+            expected_lines => [qq{blocked command: sudo zfs get -H name $dataset}],
+        },
+        {
+            label => 'disallowed availability probe',
+            command => q{command -v busybox},
+            expected_lines => ['blocked command: command -v busybox'],
+        },
+        {
+            label => 'property mutation attempt',
+            command => qq{zfs set compression=lz4 $dataset},
+            expected_lines => [qq{blocked command: zfs set compression=lz4 $dataset}],
+        },
+        {
+            label => 'snapshot creation attempt',
+            command => qq{zfs snapshot $snap1},
+            expected_lines => [qq{blocked command: zfs snapshot $snap1}],
+        },
+        {
+            label => 'snapshot destroy attempt',
+            command => qq{zfs destroy $snap1},
+            expected_lines => [qq{blocked command: zfs destroy $snap1}],
+        },
+        {
+            label => 'hold attempt',
+            command => qq{zfs hold syncoid_test $snap1},
+            expected_lines => [qq{blocked command: zfs hold syncoid_test $snap1}],
+        },
+        {
+            label => 'release attempt',
+            command => qq{zfs release syncoid_test $snap1},
+            expected_lines => [qq{blocked command: zfs release syncoid_test $snap1}],
+        },
+        {
+            label => 'arbitrary stderr redirection',
+            command => qq{zfs get -H name $dataset 2>/tmp/pwned},
+            expected_lines => [qq{blocked command: zfs get -H name $dataset 2>/tmp/pwned}],
+        },
+        {
+            label => 'stdout redirection',
+            command => qq{zfs receive -A $dataset >/tmp/pwned},
+            expected_lines => [qq{blocked command: zfs receive -A $dataset >/tmp/pwned}],
+        },
+        {
+            label => 'pipeline to shell',
+            command => qq{mbuffer  -q -s 128k -m 16M | zstdmt -dc | zfs receive -F $dataset 2>&1 | sh},
+            expected_lines => [qq{blocked command: mbuffer  -q -s 128k -m 16M | zstdmt -dc | zfs receive -F $dataset 2>&1 | sh}],
+        },
+        {
+            label => 'environment prefix attempt',
+            command => q{PATH=/tmp:$PATH echo ok},
+            expected_lines => ['blocked command: PATH=/tmp:$PATH echo ok'],
+        },
+        {
+            label => 'comment suffix attempt',
+            command => q{echo ok # comment},
+            expected_lines => ['blocked command: echo ok # comment'],
+        },
+        {
+            label => 'command substitution attempt',
+            command => qq{zfs get -H name $dataset4(id)},
+            expected_lines => [qq{blocked command: zfs get -H name $dataset4(id)}],
+        },
+        {
+            label => 'backtick substitution attempt',
+            command => qq{zfs get -H name $dataset `id`},
+            expected_lines => [qq{blocked command: zfs get -H name $dataset `id`}],
+        },
+        {
+            label => 'newline injection attempt',
+            command => $newline_attack,
+            expected_lines => [
+                'blocked command: echo ok',
+                'ls',
+            ],
+        },
+        {
+            label => 'malicious follow-up after allowed send estimate',
+            command => qq{zfs send -w -nvP $snap1; zfs destroy $snap2},
+            expected_lines => [
+                qq{would run command: zfs send -w -nvP $snap1},
+                qq{blocked command: zfs destroy $snap2},
+            ],
+        },
+        {
+            label => 'malicious follow-up after allowed dataset query',
+            command => qq{zfs get -H name $dataset; rm -rf /},
+            expected_lines => [
+                qq{would run command: zfs get -H name $dataset},
+                'blocked command: rm -rf /',
+            ],
+        },
+    );
+
+    for my $case (@cases) {
+        assert_case($case->{label}, $case->{command}, $case->{expected_lines});
+    }
+};
+
+done_testing();


### PR DESCRIPTION
- Allow spaces in snapshot and dataset names sent over SSH
- Fix GUI field alignment that broke in some version of Unraid
- Handle if ZFS is not available in SSH user buddybackup's PATH
- Validate destination dataset name during connection testing
- Validate that ZFS is available and working on the remote during connection testing
- Reduce false positives for failed security validation during connection testing, and add debug logs if the test still fails